### PR TITLE
Fix test-stack setup instructions

### DIFF
--- a/4-testing/testing.md
+++ b/4-testing/testing.md
@@ -22,7 +22,7 @@ Next step is to get a clean stack selected and configured by using `TEST` target
     
 Before the test-suites can be run, we need to setup the application, like during development setup, but in the test-stack.
     
-    make TEST setup up 
+    make TEST up setup 
 
 Enter the `tester` container    
     


### PR DESCRIPTION
Fix the setup command by switching the order of the rules to be executed.

```
make TEST setup up
```

'up' should be run before 'setup', so the DB is already available:

```
make TEST up setup
```
